### PR TITLE
change from email so that sendgrid will send contacts

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -8,7 +8,7 @@ class Contact < MailForm::Base
     {
       subject: "Contact Form",
       to: "indulge@water-lily.co.uk",
-      from: %("#{name}" <#{email}>)
+      from: "indulge@water-lily.co.uk"
     }
   end
 end


### PR DESCRIPTION
Net::SMTPFatalError: 550 The from address does not match a verified Sender Identity. Mail cannot be sent until this error is resolved. Visit https://sendgrid.com/docs/for-developers/sending-email/sender-identity/ to see the Sender Identity requirements